### PR TITLE
Check compatibility with new R v4.0.2

### DIFF
--- a/3-2-2/QA.Rmd
+++ b/3-2-2/QA.Rmd
@@ -280,13 +280,11 @@ old_data <- read.csv("Y:/Data Collection and Reporting/Jemalex/CSV/indicator_3-2
     TRUE ~ as.character(Region)),
     Value = round(Value, decimal_places),
     dataset = "current") %>% 
-  rename(Birthweight = Birth.weight,
-         `Health board` = Health.Board,
-         # `Unit measure` = Unit.measure,
+  rename(Birthweight = Birthweight..grams.,
+         `Country of birth` = Country.of.birth,
          `Unit multiplier` = Unit.multiplier,
-         `Observation status` = Observation.status) %>% 
-  filter(`Health board` == "") %>% 
-  select(-`Health board`) 
+         `Neonatal period` = Neonatal.period,
+         `Observation status` = Observation.status) 
 
 csv_data <- csv_data %>% 
   mutate(Year = year) %>% 
@@ -350,7 +348,7 @@ region_plot <- all_data %>%
   filter(Birthweight == "" &
            Sex == "" &
            Age == "" &
-           Country == "England" &
+           Country == "England" & Region != "" &
            (`Country of birth` == "" | is.na(`Country of birth`))) %>% 
   ggplot(data = .,
        aes(x = Year,


### PR DESCRIPTION
Edited 3.2.2 QA.Rmd because when it was first written it was a complete overhaul of the data.
The columns referred to in the old data were therefore not relevant
once the indicator was updated. This will now work going forward.

Signed-off-by: EmmaWoodONS <emma.wood@ons.gov.uk>