### PR TITLE
unit test fixed

### DIFF
--- a/SDGupdater/tests/testthat/test_calculate_valid_rates_per_1000.R
+++ b/SDGupdater/tests/testthat/test_calculate_valid_rates_per_1000.R
@@ -48,11 +48,11 @@ test_that("calculate_valid_rates_per_1000 handles NAs correctly", {
   expect_equal(calculate_valid_rates_per_1000(c(10, 10), c(10, NA), 0), c(1000, NA))
 })
 
-test_that("calculate_valid_rates_per_1000 returns NA when numerator is <= 3 but >= 0", {
+test_that("calculate_valid_rates_per_1000 returns NA when numerator is < 3 but >= 0", {
   expect_equal(calculate_valid_rates_per_1000(0, 10, 0), NA)
   expect_equal(calculate_valid_rates_per_1000(1, 10, 0), NA)
   expect_equal(calculate_valid_rates_per_1000(2, 10, 0), NA)
-  expect_equal(calculate_valid_rates_per_1000(3, 10, 0), NA)
+  expect_equal(calculate_valid_rates_per_1000(3, 10, 0), 300)
 })
 
 test_that("calculate_valid_rates_per_1000 returns expected datatype", {


### PR DESCRIPTION
unit test was out of date. A numerator of 3 is valid, but the test expected NA. 