### PR TITLE
Temporary note on Jemalex update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,9 @@ Be critical and clear, but not mean. Ask questions and set actions.
   
 ## Finalising the automated update ## 
 Timely reviews are important as it will be easier for you to fix any bugs while the indicator is fresh in your mind.  
-Once your code has passed [review](#reviewing-indicator-automations) it can be merged into main. Whenever the main branch is changed it must be pulled down into the repostiory clone in Jemalex.  
+Once your code has passed [review](#reviewing-indicator-automations) it can be merged into main. Whenever the main branch is changed it must be pulled down into the repostiory clone in Jemalex.
+
+**<ins>IMPORTANT NOTE:</ins> We are currently experiencing some issues with anyone being able to update the branch on Jemalex - there seems to be a permissions problem and only the person who cloned it can currently update. Until this is resolved, please let Atanaska Nikolova know that you have had an approved automation merged into the main branch. Atanaska will then be able to update the automation folder on Jemalex. Ignore the instructions until the end of this section**
 
 - Using Git Bash:
 > 


### PR DESCRIPTION
Just specifying that currently people can't pull anything on Jemalex. I was going to go into manual overwrite instructions, but I think it'll just confuse everyone (i.e. download main into a zip and overwrite what's on Jemalex with that new version). 

I was also thinking to suggest that people can just run automations from local  branches and then paste the outputs into the respective QA folder for the indicator - this avoids having a copy of sdg_data_updates on Jemalex. But on second thought, it's not a good idea because it may be a blocker for people who don't want to have to do anything with coding and just want to run an automated update without dealing with GitBash etc.
Anyways, this pull request is just adding that "Important note" bit to CONTRUBUTING.md