### PR TITLE
Commenting out a section

### DIFF
--- a/update_indicator_main.R
+++ b/update_indicator_main.R
@@ -9,7 +9,7 @@
 # install.packages("tidyr", dependencies = TRUE, type = "win.binary")
 
 # Because SDGupdater is a local package we install it slightly differently:
-setwd("D:/Coding_repos/sdg_data_updates")
+#setwd("D:/Coding_repos/sdg_data_updates")
 
 install.packages("SDGupdater", repos = NULL, type="source", force = TRUE)
 


### PR DESCRIPTION
Line 12 `setwd("D:/Coding_repos/sdg_data_updates")` in the main update script should be commented out. When opened through Rproj the directory will be automatically set correctly. Having this statement uncommented messes up the sourcing. In fact, I think it should be completely removed, but just commenting out for now so it doesn't cause issues for people running from Jemalex (or other drives)

THIS IS A VERY MINOR CHANGE - no actual review required
