### PR TITLE
Updating the guidance folder link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Edits to existing automations will follow a similar process to new automations.
   
 ## Reviewing indicator automations ##
 Before indicator automations can be merged into the main branch, they must be reviewd.  More comprehensive [instructions for review](https://officenationalstatistics.sharepoint.com/:w:/r/sites/SusIneqSDG/Sample/Data_team/Guidance/Guidance%20-%20Peer%20review%20of%20code%20for%20automation.docx?d=w952aec2a912a44398796354c0b6bd08e&csf=1&web=1&e=ZloOWx) are given 
-in the [guidance folder](https://officenationalstatistics.sharepoint.com/sites/SusIneqSDG/Sample/Forms/AllItems.aspx?id=%2Fsites%2FSusIneqSDG%2FSample%2FData%5Fteam%2FGuidance&viewid=af1c3b4f%2Dfc56%2D4c14%2D80cc%2D63f2d2a75464) on Sharepoint.  
+in the [guidance folder](https://officenationalstatistics.sharepoint.com/sites/SusIneqSDG/Sample/Forms/AllItems.aspx?id=%2Fsites%2FSusIneqSDG%2FSample%2FData%5Fteam%2FGuidance%5Fand%5Fhandover%5Fnotes&viewid=af1c3b4f%2Dfc56%2D4c14%2D80cc%2D63f2d2a75464) on Sharepoint.  
     
 Please use the template below as the basis for your review - copy and paste it into the
 conversation and make comments on all relevant sections. This template is based on the 


### PR DESCRIPTION
This is to update the guidance folder link in the Reviewing indicator automations section of contributing.md file. The current link is not working [link](https://officenationalstatistics.sharepoint.com/sites/SusIneqSDG/Sample/Forms/AllItems.aspx?id=%2Fsites%2FSusIneqSDG%2FSample%2FData%5Fteam%2FGuidance&viewid=af1c3b4f%2Dfc56%2D4c14%2D80cc%2D63f2d2a75464). The one I am proposing to replace it with is this [link](https://officenationalstatistics.sharepoint.com/sites/SusIneqSDG/Sample/Forms/AllItems.aspx?id=%2Fsites%2FSusIneqSDG%2FSample%2FData%5Fteam%2FGuidance%5Fand%5Fhandover%5Fnotes&viewid=af1c3b4f%2Dfc56%2D4c14%2D80cc%2D63f2d2a75464). Please review it if its correct? 